### PR TITLE
Add innerStyle to override backgroundSize, backgroundPosition & backgroundRepeat.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -47,6 +47,10 @@ class PreloadImage extends React.Component {
   }
 
   render() {
+    const backgroundSize = this.props.innerStyle && this.props.innerStyle.backgroundSize ? this.props.innerStyle.backgroundSize : "cover";
+    const backgroundPosition = this.props.innerStyle && this.props.innerStyle.backgroundPosition ? this.props.innerStyle.backgroundPosition : "center";
+    const backgroundRepeat = this.props.innerStyle && this.props.innerStyle.backgroundRepeat ? this.props.innerStyle.backgroundRepeat : "no-repeat";
+
     return (
       <div
         // Required: Relative, absolute, or fixed position
@@ -63,9 +67,9 @@ class PreloadImage extends React.Component {
           bottom: 0,
           left: 0,
           backgroundImage: this.state.src,
-          backgroundSize: 'cover',
-          backgroundPosition: 'center',
-          backgroundRepeat: 'no-repeat',
+          backgroundSize: backgroundSize,
+          backgroundPosition: backgroundPosition,
+          backgroundRepeat: backgroundRepeat,
           transition: `opacity ${this.props.duration || '300ms'} ${this.props.ease || 'cubic-bezier(0.215, 0.61, 0.355, 1)'}`,
           opacity: this.state.loaded ? 1 : 0
         }}></div>


### PR DESCRIPTION
Hey, this is a small pull request to add the possibility to override the style of the inner div (the one that contains the background image), as at the moment there's no way to override `backgroundSize: 'cover'`, `backgroundPosition: 'center'`, and `backgroundRepeat: 'no-repeat'`.

This would be used as follows:

```typescript
<PreloadImage
	src={page.image}
	innerStyle={{
		backgroundSize: "contain",
		backgroundPosition: "bottom",
		backgroundRepeat: "repeat",
	}}
	lazy
/>
```

Or simply:

```typescript
<PreloadImage
	src={page.image}
	innerStyle={{ backgroundSize: "contain" }}
	lazy
/>
```

If `innerStyle` is not specified (or if any of the properties are not specified) they fallback to the default values.