### PR TITLE
Add React 17 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-preload-image",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Preload and fade in an image. Optional support for lazy loading.",
   "main": "lib/index.js",
   "module": "es/index.js",
@@ -17,7 +17,7 @@
   },
   "dependencies": {},
   "peerDependencies": {
-    "react": "16.x"
+    "react": "17.x"
   },
   "devDependencies": {
     "nwb": "0.21.x",


### PR DESCRIPTION
The purpose of this pull request is to allow `npm` and `yarn` to install this package with React `17.x`.

It seems simply switching from React 16.x to 17.x makes it work.

For now, I'm installing with `npm install github:nonoesp/react-preload-image#17.x`.

#### What this pull request does

- Set React peer dependency to 17.x in `package.json`.

Cheers! :)